### PR TITLE
Enable Global Interrupts in "extiCritical"

### DIFF
--- a/utility/zoMcu.h
+++ b/utility/zoMcu.h
@@ -4,20 +4,21 @@
 
 #define nop()					__asm__ __volatile__ ("nop" ::)
 
-#ifndef cli	// Jim
+#ifndef cli
 #define cli()					__asm__ __volatile__ ("cli" ::)
-#endif	// Jim
+#endif
 
-#ifndef sei	// Jim
+#ifndef sei
 #define sei()					__asm__ __volatile__ ("sei" ::)
-#endif	// Jim
+#endif
 
 #define enterCritical()			__asm__ __volatile__ ("in __tmp_reg__, __SREG__\n\t " \
 											  "push __tmp_reg__\n\t" \
 											  "cli" ::)
 
-#define exitCritical()			__asm__ __volatile__ ("pop __tmp_reg__ \n\t" \
-											  "out __SREG__, __tmp_reg__" ::)  
+#define exitCritical()			__asm__ __volatile__ ("sei\n\t" \
+									 "pop __tmp_reg__ \n\t" \
+											  "out __SREG__, __tmp_reg__" ::)
 
 #define returnFromInterrupt()	__asm__ __volatile__ ("reti" ::)
 


### PR DESCRIPTION
In the "enterCritical()" function, the 'cli' command is used to deactivate interrupts. However, in "exitCritical()" it is not reactivated using the 'sei' command. This creates problem when trying to send command to the SMS (using the "Supermodified" object) from an ISR. The is why the 'sei' command has been added.
