### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -22,7 +22,7 @@ end	KEYWORD2
 setProfileAcceleration	KEYWORD2
 setProfileConstantVelocity	KEYWORD2
 setCurrentLimit	KEYWORD2
-setPIDgainP KEYWORD2
+setPIDgainP	KEYWORD2
 setPIDgainI	KEYWORD2
 setPIDgainD	KEYWORD2
 setDurationForCurrentLimit	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords